### PR TITLE
Add support for finding and counting chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Notes:
 4. Run `sh _prepare.sh` command to create temp database file (duckdb file) that contains the simplified views that is used in different shell scripts. These views are not copying the actual data, they are just views referring to the actual JSON files converted from mongodb bson files.
 5. Run any of the shell script. These scripts are plain and simple, you can read the code to understand what the parameters, or add `-h` argument to the scripts to see help text for each one of them (i.e: `sh find-pages-by-feature-name.sh -h`)
 
-
 ## Video Tutorial
 
 [![Video Tutorial](https://img.youtube.com/vi/Sy3FjQv73VM/0.jpg)](https://www.youtube.com/watch?v=Sy3FjQv73VM)
@@ -37,25 +36,51 @@ The video and tutorial can be found in "[How to check feature/content-source usa
 
 ## Scripts
 
-#### `all-features-usage`
-produces list of all features used in your pb-data (not bundle), in published pages and templates along with how many pages they are used in and the number of times (instances) they are used in these pages.
+### `all-chains-usage.sh [-c]`
+Produces list of all chains used in your pb-data (not bundle), in published pages and templates along with how many pages they are used in and the number of times (instances) they are used in these pages.
 
-#### `find-pages-by-feature-name`
-requires `-n` parameter with a feature name that will print list of pages and templates which uses this feature.
+`-c` Output in CSV format
 
+### `all-features-usage.sh [-c]`
+Produces list of all features used in your pb-data (not bundle), in published pages and templates along with how many pages they are used in and the number of times (instances) they are used in these pages.
+
+`-c` Output in CSV format
+
+### `find-pages-by-chain-name.sh -n <chain_name> [-c]`
+Produces list of pages and templates which uses a specific chain.
 You can open pagebuilder editor with the following url template with the page or template id in the query string: `https://YOURORG.arcpublishing.com/pagebuilder/editor/curate?p=PAGEID`
 
-#### `all-content-sources-usage`
+`-n` Chain name (required, min 2 characters)
+
+`-c` Output in CSV format
+
+### `find-pages-by-feature-name.sh -n <feature_name> [-c]`
+Produces list of pages and templates which uses a specific feature.
+You can open pagebuilder editor with the following url template with the page or template id in the query string: `https://YOURORG.arcpublishing.com/pagebuilder/editor/curate?p=PAGEID`
+
+`-n` Feature name (required, min 2 characters)
+
+`-c` Output in CSV format
+
+### `all-content-sources-usage.sh`
 List of all content sources, from both global content source configurations (from resolvers) and feature configurations.
-This script does NOT have csv export option.
+Note: This script does NOT have CSV output option.
 
-#### `all-page-urls`
-Lists all published pages with their URIs.
-Note: This script lists only pages and not templates. Templates are powered by dynamic URL patterns from resolvers and are not included in this script's output.
+### `all-page-urls.sh [-c]`
+Excludes templates, as they are powered by dynamic URL patterns from resolvers and are not included in this script's output.
 
-### `find-pages-by-uri`
-List all pages with URI containing the provided filter.
+`-c` Output in CSV format
 
-### `describe-page-or-template`
-Describes contents of a page or template by it's id provided by `-i` argument.
-This script shows meta data of this page (uri, title), list of features, sorted by how many times used in the page/template, and the content sources configured from features.
+### `find-pages-by-uri.sh -u <uri_filter> [-c]`
+List all pages matching URI containing the provided filter.
+
+`-u` URI filter (required, min 2 characters)
+
+`-c` Output in CSV format
+
+### `describe-page-or-template.sh -i <page_or_template_id> [-c]`
+This script shows meta data of this page (uri, title), list of chains & features, sorted by how many times used in the page/template, and the content sources configured from features.
+
+`-i` Page or Template ID (required, min 2 characters)
+
+`-c` Output in CSV format

--- a/all-chains-usage.sh
+++ b/all-chains-usage.sh
@@ -17,14 +17,14 @@ done
 
 QUERY="SELECT * FROM (
   SELECT
-    featureName,
+    chainName,
     COUNT(1) as countOfTimesUsed,
     COUNT(DISTINCT pageOrTemplateId) as countOfPagesOrTemplatesUsing
   FROM view_rendering
   LEFT JOIN view_page_and_template ON view_page_and_template.published = view_rendering.renderingVersionId
   WHERE pageOrTemplateId IS NOT NULL
-    AND featureName != ''
-  GROUP BY featureName
+    AND chainName != ''
+  GROUP BY chainName
 )
 ORDER BY countOfPagesOrTemplatesUsing DESC"
 
@@ -34,7 +34,7 @@ else
   # Print the header
   YELLOW='\033[0;33m'
   RESET='\033[0m'
-  echo "${YELLOW}\n--- All features used in published pages, sorted by most used first ---\n${RESET}"
+  echo "${YELLOW}\n--- All chains used in published pages, sorted by most used first ---\n${RESET}"
 fi
 
 duckdb _tmpview.db "$QUERY"

--- a/all-content-sources-usage.sh
+++ b/all-content-sources-usage.sh
@@ -6,8 +6,7 @@ while getopts ":hn:c" option; do
     c) # CSV output
       Csv=True;;
     h) # Help message
-      echo "Usage: $0 [-c]"
-      echo "  -c for CSV output you can pipe to a file"
+      echo "Usage: $0"
       exit 0;;
     \?) # Invalid option
       echo "Error: Invalid option"
@@ -35,12 +34,11 @@ duckdb _tmpview.db "SELECT * FROM (
   SELECT
     featureName,
     contentService,
-    COUNT(1) as countOfTimesUsed,
     COUNT(DISTINCT pageOrTemplateId) as countOfPagesOrTemplatesUsing
   FROM view_rendering
-  LEFT JOIN view_page_and_template ON view_page_and_template.published = view_rendering.renderingVersionId
-  WHERE pageOrTemplateId IS NOT NULL
+  INNER JOIN view_page_and_template ON view_page_and_template.published = view_rendering.renderingVersionId
     AND contentService != ''
+  WHERE pageOrTemplateId IS NOT NULL
   GROUP BY contentService, featureName
 )
 ORDER BY countOfPagesOrTemplatesUsing DESC"

--- a/gui.sh
+++ b/gui.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Opening DuckDB GUI with _tmpview.db database"
+duckdb -ui _tmpview.db

--- a/help.sh
+++ b/help.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+echo "Available scripts and their usage:
+
+1. all-chains-usage.sh [-c]
+   Shows all chains used in published pages, templates and how many times they are used
+   -c: Output in CSV format
+
+2. all-features-usage.sh [-c]
+   Shows all features used in published pages, templates and how many times they are used
+   -c: Output in CSV format
+
+3. find-pages-by-chain-name.sh -n <chain_name> [-c]
+   Find all pages using a specific chain
+   -n: Chain name (required, min 2 characters)
+   -c: Output in CSV format
+
+4. find-pages-by-feature-name.sh -n <feature_name> [-c]
+   Find all pages using a specific feature
+   -n: Feature name (required, min 2 characters)
+   -c: Output in CSV format
+
+5. all-content-sources-usage.sh
+   Shows global content sources usage across resolvers and features
+
+6. all-page-urls.sh [-c]
+   Shows all published pages with their URIs
+   -c: Output in CSV format
+
+7. find-pages-by-uri.sh -u <uri_filter> [-c]
+   Find all pages with a specific URI
+   -u: URI filter (required, min 2 characters)
+   -c: Output in CSV format
+
+8. describe-page-or-template.sh -i <page_or_template_id> [-c]
+   Describe a specific page or template with its chains, features, and content sources
+   -i: Page or Template ID (required, min 2 characters)
+   -c: Output in CSV format
+"


### PR DESCRIPTION
Greetings Arc XP, this PR including some additions for counting chains and adjustments to some queries.

### Changes included

1. Create `help.sh` file, to echo quick help to terminal. Without having to reference the available scipts elsewhere.

2. Create `gui.sh` file, to open the [DuckDB Local UI](https://duckdb.org/2025/03/12/duckdb-ui.html), and view the "_tmpview.db" file.

3. Add new "chain" block related scripts. That report similiar info as the "feature" scripts.
- `all-chains-usage.sh`
- `find-pages-by-chain-name.sh`

4. Update existing script, to print the page's "chain" blocks, in addition to the "feature" blocks.
- `describe-page-or-template.sh`

5. Update existing script, to correctly count the (chain, feature, content sources) instances.
The previous counts were way to high, counting the totals from all revisions, and not just the one page.
The current counts for "Print Features" and "Print Chains" look correct to me now.
- `describe-page-or-template.sh`
- `all-content-sources-usage.sh`

### Content Sources issue

The previous and current counts for "Print Content Sources" (for features) are always zero, regardless of the page. I believe there is a flaw in the logic for this DB query. I suspect that feature blocks don't actually store their content source service name in the root `contentService` property.

Instead, they are stored under the `customFields` object. The query would need to be updated to recursively search for the `contentService` property, within all custom fields. However, my MongoDB query skills aren't very good.

Feature blocks can have multiple content sources associated with them. Each having a unique custom field name. 
- https://dev.arcxp.com/pagebuilder-engine/developer-docs/how-to-dynamically-configure-content/
